### PR TITLE
Forslag til endringer for å forenkle bygging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,13 +180,17 @@
 
 	<repositories>
 		<repository>
-			<id>soknadarkiv-schema</id>
-			<url>https://maven.pkg.github.com/navikt/soknadarkiv-schema</url>
+			<id>github</id>
+			<name>nav github</name>
+			<url>https://github-package-registry-mirror.gc.nav.no/cached/maven-release</url>
 		</repository>
-
 		<repository>
 			<id>confluent</id>
 			<url>https://packages.confluent.io/maven</url>
+		</repository>
+		<repository>
+			<id>central</id>
+			<url>https://repo1.maven.org/maven2</url>
 		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
Skal kunne bygge lokalt uten proxy-settings i maven (ofte konfigurert i MAVEN_OPTS), har flytta config ut i pom.xml. 

Denne bygger fra scratch uten settings.xml og maven proxy-settings

Siden settings.xml ikke trenger å være opprettet, hverken på github eller lokalt, som vil kunne forenkle action'en som bygger bittelitt

Kodet på delt'ish skjerm med @sturleh 