### PR TITLE
Future metric fix

### DIFF
--- a/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/ApplicationTests.kt
+++ b/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/ApplicationTests.kt
@@ -81,14 +81,19 @@ class ApplicationTests {
 	@BeforeAll
 	fun setupKafkaProducersAndListeners() {
 		kafkaProducer = KafkaProducer(kafkaConfigMap())
-		kafkaProducerForBadData = KafkaProducer(kafkaConfigMap().also { it[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java })
+		kafkaProducerForBadData = KafkaProducer(kafkaConfigMap()
+			.also { it[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java })
 
 		kafkaListener = KafkaListener(appConfiguration.kafkaConfig)
 	}
 
 	@BeforeEach
 	fun setup() {
-		setupMockedNetworkServices(portToExternalServices!!, appConfiguration.config.joarkUrl, appConfiguration.config.filestorageUrl)
+		setupMockedNetworkServices(
+			portToExternalServices!!,
+			appConfiguration.config.joarkUrl,
+			appConfiguration.config.filestorageUrl
+		)
 
 		maxNumberOfAttempts = appConfiguration.config.retryTime.size
 	}
@@ -163,7 +168,7 @@ class ApplicationTests {
 			"send files to archive" to 0,
 			"delete files from filestorage" to 0
 		))
-		verifyArchivingMetrics(tasksGivenUpOnBefore + 1, metrics.getTasksGivenUpOn())
+		verifyArchivingMetrics(tasksGivenUpOnBefore + 1, { metrics.getTasksGivenUpOn() })
 	}
 
 	@Test
@@ -176,7 +181,7 @@ class ApplicationTests {
 		putDataOnKafkaTopic(key, createSoknadarkivschema())
 
 		verifyProcessingEvents(key, mapOf(RECEIVED to 1, STARTED to maxNumberOfAttempts, ARCHIVED to 0, FINISHED to 0, FAILURE to 1))
-		verifyArchivingMetrics(tasksGivenUpOnBefore + 1, metrics.getTasksGivenUpOn())
+		verifyArchivingMetrics(tasksGivenUpOnBefore + 1, { metrics.getTasksGivenUpOn() })
 
 		val failedKeys = taskListService.getFailedTasks()
 		assertTrue(failedKeys.contains(key))
@@ -184,7 +189,7 @@ class ApplicationTests {
 		taskListService.startPaNytt(key)
 
 		verifyProcessingEvents(key, mapOf(FINISHED to 1))
-		verifyArchivingMetrics(tasksGivenUpOnBefore + 0, metrics.getTasksGivenUpOn())
+		verifyArchivingMetrics(tasksGivenUpOnBefore + 0, { metrics.getTasksGivenUpOn() })
 	}
 
 
@@ -234,12 +239,12 @@ class ApplicationTests {
 			"delete files from filestorage" to 1
 		))
 
-		verifyArchivingMetrics(getFilestorageSuccessesBefore + 2, metrics.getGetFilestorageSuccesses())
-		verifyArchivingMetrics(delFilestorageSuccessesBefore + 1, metrics.getDelFilestorageSuccesses())
-		verifyArchivingMetrics(joarkErrorsBefore + 1, metrics.getJoarkErrors())
-		verifyArchivingMetrics(joarkSuccessesBefore + 1, metrics.getJoarkSuccesses())
-		verifyArchivingMetrics(tasksBefore + 0, metrics.getTasks(), "Should have created and finished task")
-		verifyArchivingMetrics(tasksGivenUpOnBefore + 0, metrics.getTasksGivenUpOn(), "Should not have given up on any task")
+		verifyArchivingMetrics(getFilestorageSuccessesBefore + 2, { metrics.getGetFilestorageSuccesses() })
+		verifyArchivingMetrics(delFilestorageSuccessesBefore + 1, { metrics.getDelFilestorageSuccesses() })
+		verifyArchivingMetrics(joarkErrorsBefore + 1, { metrics.getJoarkErrors() })
+		verifyArchivingMetrics(joarkSuccessesBefore + 1, { metrics.getJoarkSuccesses() })
+		verifyArchivingMetrics(tasksBefore + 0, { metrics.getTasks() }, "Should have created and finished task")
+		verifyArchivingMetrics(tasksGivenUpOnBefore + 0, { metrics.getTasksGivenUpOn() }, "Should not have given up on any task")
 	}
 
 	@Test
@@ -261,7 +266,7 @@ class ApplicationTests {
 			"send files to archive" to 1,
 			"delete files from filestorage" to 1
 		))
-		verifyArchivingMetrics(tasksGivenUpOnBefore + 0, metrics.getTasksGivenUpOn(), "Should not have given up on any task")
+		verifyArchivingMetrics(tasksGivenUpOnBefore + 0, { metrics.getTasksGivenUpOn() }, "Should not have given up on any task")
 	}
 
 	@Test
@@ -289,11 +294,11 @@ class ApplicationTests {
 			"delete files from filestorage" to 1 // Metric succeeds even if the operation fails
 		))
 
-		verifyArchivingMetrics(getFilestorageSuccessesBefore + 1, metrics.getGetFilestorageSuccesses())
-		verifyArchivingMetrics(delFilestorageSuccessesBefore + 0, metrics.getDelFilestorageSuccesses())
-		verifyArchivingMetrics(delFilestorageErrorsBefore + 1, metrics.getDelFilestorageErrors())
-		verifyArchivingMetrics(joarkErrorsBefore + 0, metrics.getJoarkErrors())
-		verifyArchivingMetrics(joarkSuccessesBefore + 1, metrics.getJoarkSuccesses())
+		verifyArchivingMetrics(getFilestorageSuccessesBefore + 1, { metrics.getGetFilestorageSuccesses() })
+		verifyArchivingMetrics(delFilestorageSuccessesBefore + 0, { metrics.getDelFilestorageSuccesses() })
+		verifyArchivingMetrics(delFilestorageErrorsBefore + 1, { metrics.getDelFilestorageErrors() })
+		verifyArchivingMetrics(joarkErrorsBefore + 0, { metrics.getJoarkErrors() })
+		verifyArchivingMetrics(joarkSuccessesBefore + 1, { metrics.getJoarkSuccesses() })
 	}
 
 	@Test
@@ -341,13 +346,13 @@ class ApplicationTests {
 			"delete files from filestorage" to 1
 		))
 
-		verifyArchivingMetrics(getFilestorageErrorsBefore + 0, metrics.getGetFilestorageErrors())
-		verifyArchivingMetrics(getFilestorageSuccessesBefore + 1, metrics.getGetFilestorageSuccesses())
-		verifyArchivingMetrics(delFilestorageSuccessesBefore + 1, metrics.getDelFilestorageSuccesses())
-		verifyArchivingMetrics(joarkErrorsBefore + 0, metrics.getJoarkErrors())
-		verifyArchivingMetrics(joarkSuccessesBefore + 0, metrics.getJoarkSuccesses())
-		verifyArchivingMetrics(tasksBefore, metrics.getTasks())
-		verifyArchivingMetrics(tasksGivenUpOnBefore, metrics.getTasksGivenUpOn())
+		verifyArchivingMetrics(getFilestorageErrorsBefore + 0, { metrics.getGetFilestorageErrors() })
+		verifyArchivingMetrics(getFilestorageSuccessesBefore + 1, { metrics.getGetFilestorageSuccesses() })
+		verifyArchivingMetrics(delFilestorageSuccessesBefore + 1, { metrics.getDelFilestorageSuccesses() })
+		verifyArchivingMetrics(joarkErrorsBefore + 0, { metrics.getJoarkErrors() })
+		verifyArchivingMetrics(joarkSuccessesBefore + 0, { metrics.getJoarkSuccesses() })
+		verifyArchivingMetrics(tasksBefore, { metrics.getTasks() })
+		verifyArchivingMetrics(tasksGivenUpOnBefore, { metrics.getTasksGivenUpOn() })
 	}
 
 	@Test
@@ -375,13 +380,13 @@ class ApplicationTests {
 			"delete files from filestorage" to 0
 		))
 
-		verifyArchivingMetrics(getFilestorageErrorsBefore + maxNumberOfAttempts, metrics.getGetFilestorageErrors())
-		verifyArchivingMetrics(getFilestorageSuccessesBefore + 0, metrics.getGetFilestorageSuccesses())
-		verifyArchivingMetrics(delFilestorageSuccessesBefore + 0, metrics.getDelFilestorageSuccesses())
-		verifyArchivingMetrics(joarkErrorsBefore + 0, metrics.getJoarkErrors())
-		verifyArchivingMetrics(joarkSuccessesBefore + 0, metrics.getJoarkSuccesses())
-		verifyArchivingMetrics(tasksBefore + 1, metrics.getTasks())
-		verifyArchivingMetrics(tasksGivenUpOnBefore + 1, metrics.getTasksGivenUpOn())
+		verifyArchivingMetrics(getFilestorageErrorsBefore + maxNumberOfAttempts, { metrics.getGetFilestorageErrors() })
+		verifyArchivingMetrics(getFilestorageSuccessesBefore + 0, { metrics.getGetFilestorageSuccesses() })
+		verifyArchivingMetrics(delFilestorageSuccessesBefore + 0, { metrics.getDelFilestorageSuccesses() })
+		verifyArchivingMetrics(joarkErrorsBefore + 0, { metrics.getJoarkErrors() })
+		verifyArchivingMetrics(joarkSuccessesBefore + 0, { metrics.getJoarkSuccesses() })
+		verifyArchivingMetrics(tasksBefore + 1, { metrics.getTasks() })
+		verifyArchivingMetrics(tasksGivenUpOnBefore + 1, { metrics.getTasksGivenUpOn() })
 	}
 
 	@Test
@@ -409,18 +414,19 @@ class ApplicationTests {
 			"delete files from filestorage" to 1
 		))
 
-		verifyArchivingMetrics(getFilestorageErrorsBefore + 1, metrics.getGetFilestorageErrors())
-		verifyArchivingMetrics(getFilestorageSuccessesBefore + 0, metrics.getGetFilestorageSuccesses())
-		verifyArchivingMetrics(delFilestorageSuccessesBefore + 0, metrics.getDelFilestorageSuccesses())
-		verifyArchivingMetrics(joarkErrorsBefore + 0, metrics.getJoarkErrors())
-		verifyArchivingMetrics(joarkSuccessesBefore + 0, metrics.getJoarkSuccesses())
-		verifyArchivingMetrics(tasksBefore, metrics.getTasks())
-		verifyArchivingMetrics(tasksGivenUpOnBefore, metrics.getTasksGivenUpOn())
+		verifyArchivingMetrics(getFilestorageErrorsBefore + 1, { metrics.getGetFilestorageErrors() })
+		verifyArchivingMetrics(getFilestorageSuccessesBefore + 0, { metrics.getGetFilestorageSuccesses() })
+		verifyArchivingMetrics(delFilestorageSuccessesBefore + 0, { metrics.getDelFilestorageSuccesses() })
+		verifyArchivingMetrics(joarkErrorsBefore + 0, { metrics.getJoarkErrors() })
+		verifyArchivingMetrics(joarkSuccessesBefore + 0, { metrics.getJoarkSuccesses() })
+		verifyArchivingMetrics(tasksBefore, { metrics.getTasks() })
+		verifyArchivingMetrics(tasksGivenUpOnBefore, { metrics.getTasksGivenUpOn() })
 	}
 
 
-	private fun verifyArchivingMetrics(expected: Double, actual: Double, message: String? = null) {
-		loopAndVerify(expected.toInt(), { actual.toInt() }, { assertEquals(expected, actual, message) })
+	private fun verifyArchivingMetrics(expected: Double, actual: () -> Double, message: String? = null) {
+		loopAndVerify(expected.toInt(), { actual.invoke().toInt() },
+			{ assertEquals(expected.toInt(), actual.invoke().toInt(), message) })
 	}
 
 	private fun verifyProcessingEvents(key: Key, eventTypeAndCount: Map<EventTypes, Int>) {

--- a/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/TaskListServiceTests.kt
+++ b/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/TaskListServiceTests.kt
@@ -99,25 +99,24 @@ class TaskListServiceTests {
 		taskListService.addOrUpdateTask(key, createSoknadarkivschema(), EventTypes.RECEIVED)
 		TimeUnit.SECONDS.sleep(startUpSecondsForTest + 2)
 
-		verify(archiverService, times(1)).archive(eq(key), any(), any())
-		verify(archiverService, times(1)).deleteFiles(eq(key), any())
-		verify(scheduler, times(1)).schedule(any(), any())
+		verify(archiverService, timeout(10_000).times(1)).archive(eq(key), any(), any())
+		verify(archiverService, timeout(10_000).times(1)).deleteFiles(eq(key), any())
+		verify(scheduler, timeout(10_000).times(1)).schedule(any(), any())
 		loopAndVerify(0, { taskListService.listTasks().size })
 	}
 
 	@Test
 	fun `Archiving does not succeed - will not remove task from list but attempt to schedule again`() {
-		val count = 0
 		val key = UUID.randomUUID().toString()
 		runScheduledTaskOnScheduling()
 		whenever(archiverService.archive(eq(key), any(), any())).thenThrow(RuntimeException("Mocked exception"))
 
 		taskListService.addOrUpdateTask(key, createSoknadarkivschema(), EventTypes.RECEIVED)
 
-		loopAndVerify(count + 1, { getTaskListCount(key) })
+		loopAndVerify(1, { getTaskListCount(key) })
 		assertFalse(taskListService.listTasks().isEmpty())
-		verify(archiverService, atLeast(1)).archive(eq(key), any(), any())
-		verify(scheduler, atLeast(2)).schedule(any(), any())
+		verify(archiverService, timeout(10_000).atLeast(1)).archive(eq(key), any(), any())
+		verify(scheduler, timeout(10_000).atLeast(2)).schedule(any(), any())
 	}
 
 


### PR DESCRIPTION
Vi har noe tester som av og til kan gå feil. Denne PR skal, håper jeg, fikse de.

ApplicationTests har hatt en bugg i `verifyArchivingMetrics` - en funksjon som skal verifisere at en metric-verdi er riktig etter at testet kjört. Funksjonen kjörer en loop for å verifisere at verdien er riktig tids nok. Buggen er at den burde ta in funksjonsreferanse (lambda), men istedenfor tatt in et verdi. Looping-mekanismen blir dermed resultatlös.

I `TaskListServiceTests` så har jeg lagt in en timeout på verifiseringen.