### PR TITLE
Lower kafka version

### DIFF
--- a/arkiverer/pom.xml
+++ b/arkiverer/pom.xml
@@ -16,6 +16,7 @@
 		<arkivering-schemas.version>6b4ceead30</arkivering-schemas.version>
 		<token-support.version>1.3.9</token-support.version>
 
+		<kafka.version>2.8.1</kafka.version>
 		<kafka-streams-avro-serde.version>6.1.1</kafka-streams-avro-serde.version>
 		<jackson-module-kotlin.version>2.13.1</jackson-module-kotlin.version>
 		<konfig.version>1.6.10.0</konfig.version>

--- a/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/config/Scheduler.kt
+++ b/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/config/Scheduler.kt
@@ -1,29 +1,27 @@
 package no.nav.soknad.arkivering.soknadsarkiverer.config
 
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
-import org.springframework.stereotype.Service
 import java.time.Instant
+import javax.annotation.PostConstruct
 
-@Service
+@EnableScheduling
+@Configuration
 class Scheduler {
 
-	@Autowired
-	private lateinit var normalTaskScheduler: ThreadPoolTaskScheduler
+	private val normalTaskScheduler = threadPoolTaskScheduler(5)
+	private val singleTaskScheduler = threadPoolTaskScheduler(1)
 
-	@Autowired
-	private lateinit var singleTaskScheduler: ThreadPoolTaskScheduler
-
-	@Bean(name = ["normalTaskScheduler"])
-	fun normalTaskScheduler() = threadPoolTaskScheduler(5)
-
-	@Bean(name = ["singleTaskScheduler"])
-	fun singleTaskScheduler() = threadPoolTaskScheduler(1)
-
-	fun threadPoolTaskScheduler(poolSize: Int) = ThreadPoolTaskScheduler().also {
+	private fun threadPoolTaskScheduler(poolSize: Int) = ThreadPoolTaskScheduler().also {
 		it.poolSize = poolSize
 		it.setThreadNamePrefix("ThreadPoolTaskSchedulerOfSize${poolSize}_")
+	}
+
+	@PostConstruct
+	fun setup() {
+		normalTaskScheduler.initialize()
+		singleTaskScheduler.initialize()
 	}
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.1</version>
+		<version>2.6.2</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
Spring Boot 2.6.* tar in Kafka versjon 3.0.0. Av noen grunn så kan soknadsarkiverer ikke kjöre kafka 3.0.0, men trenger 2.8.*. Jeg er ikke sikker på hvorfor (kanskje er versjonen av Kafka-brokern onprem ikke kompatibel med Kafka 3.0.0?), men når vi pröver at kjöre Kafka 3.0.0 så kan appen ikke starte fordi den er missfornöyd med NOT_ENOUGH_REPLICAS.

Dette löser problemet med at sette ner Kafka-versjonen til 2.8.1. Når vi går til GCP och Aiven Kafka kan vi igjen se på om vi kan gå til Kafka 3.0.0.

Denne PR erstatter #86 (som altså ikke kan kjöre)