### PR TITLE
Fixing concurrent modification exception in test Kafka listener

### DIFF
--- a/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/utils/KafkaListener.kt
+++ b/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/utils/KafkaListener.kt
@@ -2,6 +2,11 @@ package no.nav.soknad.arkivering.soknadsarkiverer.utils
 
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import no.nav.soknad.arkivering.avroschemas.InnsendingMetrics
 import no.nav.soknad.arkivering.avroschemas.ProcessingEvent
 import no.nav.soknad.arkivering.soknadsarkiverer.config.AppConfiguration
@@ -22,6 +27,7 @@ class KafkaListener(private val kafkaConfig: AppConfiguration.KafkaConfig) {
 	private val logger = LoggerFactory.getLogger(javaClass)
 	private val verbose = true
 
+	private val lock = Mutex()
 	private val metricsReceived          = mutableListOf<Pair<Key, InnsendingMetrics>>()
 	private val messagesReceived         = mutableListOf<Pair<Key, String>>()
 	private val processingEventsReceived = mutableListOf<Pair<Key, ProcessingEvent>>()
@@ -50,15 +56,38 @@ class KafkaListener(private val kafkaConfig: AppConfiguration.KafkaConfig) {
 
 		metricsStream
 			.peek { key, metrics -> log("$key: Metrics received  - $metrics") }
-			.foreach { key, metrics -> metricsReceived.add(key to metrics) }
+			.foreach { key, metrics -> addRecord(metricsReceived, key, metrics) }
 
 		messagesStream
 			.peek { key, message -> log("$key: Message received  - $message") }
-			.foreach { key, message -> messagesReceived.add(key to message) }
+			.foreach { key, message -> addRecord(messagesReceived, key, message) }
 
 		processingEventTopicStream
 			.peek { key, entity -> log("$key: Processing Events - $entity") }
-			.foreach { key, entity -> processingEventsReceived.add(key to entity) }
+			.foreach { key, entity -> addRecord(processingEventsReceived, key, entity) }
+	}
+
+	private fun <T> addRecord(list: MutableList<Pair<Key, T>>, key: Key, record: T) {
+		performMutexGuardedOperation { list.add(key to record) }
+	}
+
+	private fun <T> getRecords(list: MutableList<Pair<Key, T>>): List<Record<T>> {
+		return performMutexGuardedOperation { list.map { Record(it.first, it.second) } }
+	}
+
+	/**
+	 * If we try to add a new record to the list of previously seen records, and at the same time map all
+	 * seen records to return them, then we get a ConcurrentModificationException. Use [lock], a [Mutex] to
+	 * guard against concurrent modification.
+	 */
+	private fun <T> performMutexGuardedOperation(operation: () -> T): T {
+		return runBlocking {
+			withContext(Dispatchers.Default) {
+				lock.withLock {
+					operation.invoke()
+				}
+			}
+		}
 	}
 
 	private fun log(message: String) {
@@ -98,9 +127,9 @@ class KafkaListener(private val kafkaConfig: AppConfiguration.KafkaConfig) {
 	}
 
 
-	fun getMetrics() = metricsReceived.map { Record(it.first, it.second) }
-	fun getMessages() = messagesReceived.map { Record(it.first, it.second) }
-	fun getProcessingEvents() = processingEventsReceived.map { Record(it.first, it.second) }
+	fun getMetrics() = getRecords(metricsReceived)
+	fun getMessages() = getRecords(messagesReceived)
+	fun getProcessingEvents() = getRecords(processingEventsReceived)
 
 	data class Record<T>(val key: Key, val value: T)
 }


### PR DESCRIPTION
Vi har en hjelpeklass til testene, KafkaListener, som lytter på topics og stopper allt den ser i en liste av records. Testene ligger og poller listen for å sjekke at forventede Kafkameldinger har dukket opp.

Det blir ConcurrentModificationException hvis en tråd poller listen og en annen pröver at legge en ny record til listen samtidligt. Denne PRen skal, håper jeg, fikse feilet med hjelp av at bruke `CopyOnWriteArrayList`.