### PR TITLE
Erstatt deprecated

### DIFF
--- a/arkiverer/innsendingsIds.json
+++ b/arkiverer/innsendingsIds.json
@@ -1,1 +1,1 @@
-{"innsendingIds":["9fb024d2-43c7-48ae-bd38-27de0d0921ac"]}
+{"innsendingIds":["ade546aa-ba3d-4fa1-80f2-4b6c7f112e53"]}

--- a/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/config/WebClientConfig.kt
+++ b/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/config/WebClientConfig.kt
@@ -51,8 +51,8 @@ class WebClientConfig(private val maxMessageSize: Int = 1024 * 1024 * 325) {
 		val httpClient = HttpClient.create()
 			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000)
 			.doOnConnected { conn -> conn
-				.addHandlerLast(ReadTimeoutHandler(2 * 60))
-				.addHandlerLast(WriteTimeoutHandler(2 * 60))
+				.addHandlerLast(ReadTimeoutHandler(3 * 60))
+				.addHandlerLast(WriteTimeoutHandler(3 * 60))
 			}
 
 		val exchangeStrategies = ExchangeStrategies.builder()

--- a/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/config/WebClientConfig.kt
+++ b/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/config/WebClientConfig.kt
@@ -48,13 +48,13 @@ class WebClientConfig(private val maxMessageSize: Int = 1024 * 1024 * 325) {
 			?: throw RuntimeException("Could not find oauth2 client config for archiveWebClient")
 
 		logClientProperties(properties)
-		val tcpClient = TcpClient.create()
+		val httpClient = HttpClient.create()
 			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000)
-			.doOnConnected { connection: Connection ->
-				connection
-					.addHandlerLast(ReadTimeoutHandler(2 * 60))
-					.addHandlerLast(WriteTimeoutHandler(2 * 60))
+			.doOnConnected { conn -> conn
+				.addHandlerLast(ReadTimeoutHandler(2 * 60))
+				.addHandlerLast(WriteTimeoutHandler(2 * 60))
 			}
+
 		val exchangeStrategies = ExchangeStrategies.builder()
 			.codecs { configurer: ClientCodecConfigurer ->
 				configurer
@@ -66,7 +66,7 @@ class WebClientConfig(private val maxMessageSize: Int = 1024 * 1024 * 325) {
 		return WebClient.builder()
 			.filter(bearerTokenFilter(properties, oAuth2AccessTokenService))
 			.exchangeStrategies(exchangeStrategies)
-			.clientConnector(ReactorClientHttpConnector(HttpClient.from(tcpClient)))
+			.clientConnector(ReactorClientHttpConnector(httpClient))
 			.build()
 	}
 

--- a/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/config/WebClientConfig.kt
+++ b/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/config/WebClientConfig.kt
@@ -51,8 +51,8 @@ class WebClientConfig(private val maxMessageSize: Int = 1024 * 1024 * 325) {
 		val httpClient = HttpClient.create()
 			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000)
 			.doOnConnected { conn -> conn
-				.addHandlerLast(ReadTimeoutHandler(3 * 60))
-				.addHandlerLast(WriteTimeoutHandler(3 * 60))
+				.addHandlerLast(ReadTimeoutHandler(4 * 60))
+				.addHandlerLast(WriteTimeoutHandler(4 * 60))
 			}
 
 		val exchangeStrategies = ExchangeStrategies.builder()

--- a/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/arkivservice/JournalpostClient.kt
+++ b/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/arkivservice/JournalpostClient.kt
@@ -35,8 +35,9 @@ class JournalpostClient(@Value("\${joark.host}") private val joarkHost: String,
 			logger.info("$key: About to create journalpost for behandlingsId: '${soknadarkivschema.behandlingsid}'")
 			val request = createOpprettJournalpostRequest(soknadarkivschema, attachedFiles)
 
-			if (request.dokumenter.first().dokumentvarianter.size != soknadarkivschema.mottatteDokumenter.filter { it.erHovedskjema }.size) {
-				logger.warn("$key: Antall mottatte varianter av hovedskjema ulikt antall som skal arkiveres ${request.dokumenter.first().dokumentvarianter}")
+			val mainDocVariantFormats = soknadarkivschema.mottatteDokumenter.filter { it.erHovedskjema }.flatMap { it.mottatteVarianter }.groupBy { it.variantformat }
+			if (mainDocVariantFormats.any { it.value.size > 1} ) {
+				logger.warn("$key: Mottatte flere varianter av hovedskjema med samme variantfomat.  ${mainDocVariantFormats.filter { it.value.size > 1 }.map { it.key }}")
 			}
 
 			val client = if (soknadarkivschema.arkivtema == "BID") bidClient else webClient

--- a/arkiverer/src/main/resources/application.yml
+++ b/arkiverer/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port: 8091
 
 cron:
-  startRetryOfFailedArchiving: 0 0 16 24 MAR ?
+  startRetryOfFailedArchiving: 0 0 14 11 MAY ?
 failedApplications: ""
 
 management:

--- a/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/schedule/ReSendFailedApplicationsTests.kt
+++ b/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/schedule/ReSendFailedApplicationsTests.kt
@@ -66,7 +66,8 @@ class ReSendFailedApplicationsTests {
 	@Test
 	fun lagBase64Encoded() {
 		/*
-		Denne testen benyttes for å generere en Base64encoded string som kan legges inn som value i google secret.
+		Denne testen benyttes for å generere en Base64encoded string som kan legges inn som value i google secret, f.eks.
+		FAILED_APPLICATIONS=eyJpbm5zZW5kaW5nSWRzIjpbImFkZTU0NmFhLWJhM2QtNGZhMS04MGYyLTRiNmM3ZjExMmU1MyJdfQo=
 		 */
 		val jsonByteArray = readeBytesFromFile("innsendingsIds.json")
 

--- a/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/converter/MessageConverterTests.kt
+++ b/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/converter/MessageConverterTests.kt
@@ -260,6 +260,28 @@ class MessageConverterTests {
 	}
 
 	@Test
+	fun `Several documentvariants -- should check main document variantformats and filter duplicates`() {
+		val uuid0 = UUID.randomUUID().toString()
+		val uuid1 = UUID.randomUUID().toString()
+		val createdAt = OffsetDateTime.now(ZoneOffset.UTC)
+		val files = listOf(FileData(uuid0, "apa".toByteArray(), createdAt), FileData(uuid1, "bepa".toByteArray(), createdAt))
+
+		val schema = SoknadarkivschemaBuilder()
+			.withMottatteDokumenter(
+
+				MottattDokumentBuilder()
+					.withErHovedskjema(true)
+					.withMottatteVarianter(MottattVariantBuilder().withUuid(uuid0).build())
+					.withMottatteVarianter(MottattVariantBuilder().withUuid(uuid1).build())
+					.build(),
+				)
+			.build()
+
+
+		assertEquals(1, createOpprettJournalpostRequest(schema, files).dokumenter.first().dokumentvarianter.size)
+	}
+
+	@Test
 	fun `No Hovedskjema -- should throw exception`() {
 		val uuid0 = UUID.randomUUID().toString()
 		val uuid1 = UUID.randomUUID().toString()


### PR DESCRIPTION
Følgende er endret:
Erstattet deprecated kode
Økt read/write-timeout fra 2 - 4 minutter.
Fikset feil på logging
Lagt til tester for kontroll og filtrering av hoveddokument varianter med like arkivformat