### PR TITLE
Redusert maks filnavnlengde til 190-5 karakterer.

### DIFF
--- a/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/arkivservice/converter/MessageConverter.kt
+++ b/arkiverer/src/main/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/arkivservice/converter/MessageConverter.kt
@@ -98,7 +98,7 @@ private fun createDokumentVariant(variant: Variant, attachedFiles: List<FileInfo
 
 	val filtype = if (variant.filtype.equals("PDF/A",true) ) "PDFA" else variant.filtype.uppercase()
 	return DokumentVariant(
-		filnavn = variant.filnavn.take(200 - 5), // filename + extention can be maximum 200 characters
+		filnavn = variant.filnavn.take(190 - 5), // filename + extention can be maximum 190 characters
 		filtype = filtype,
 		fysiskDokument = attachedFile[0].content!!,
 		variantformat = variant.variantFormat ?: "ARKIV")

--- a/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/converter/MessageConverterTests.kt
+++ b/arkiverer/src/test/kotlin/no/nav/soknad/arkivering/soknadsarkiverer/service/converter/MessageConverterTests.kt
@@ -279,7 +279,7 @@ class MessageConverterTests {
 		val schema2 = schema.copy(dokumenter = docs)
 
 		val arkivData = createOpprettJournalpostRequest(schema2, uploadedfiles)
-		assertEquals(200 - 5, arkivData.dokumenter[2].dokumentvarianter[0].filnavn.length)
+		assertEquals(190 - 5, arkivData.dokumenter[2].dokumentvarianter[0].filnavn.length)
 	}
 
 


### PR DESCRIPTION
Ved å redusere maks antall karakterer på filnavnet med 10 karakterer regner jeg med at søknaden lar seg arkivere